### PR TITLE
Don't invoke `ExDTLS.do_handshake/1` in server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package can be installed by adding `membrane_dtls_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_dtls_plugin, "~> 0.2.0"}
+    {:membrane_dtls_plugin, "~> 0.2.1"}
   ]
 end
 ```

--- a/lib/handshake.ex
+++ b/lib/handshake.ex
@@ -28,7 +28,7 @@ defmodule Membrane.DTLS.Handshake do
   end
 
   @impl Handshake
-  def connection_ready(%{dtls: dtls, client_mode: false}), do: :ok
+  def connection_ready(%{client_mode: false}), do: :ok
 
   @impl Handshake
   def connection_ready(%{dtls: dtls, client_mode: true}) do

--- a/lib/handshake.ex
+++ b/lib/handshake.ex
@@ -24,11 +24,14 @@ defmodule Membrane.DTLS.Handshake do
       )
 
     {:ok, fingerprint} = ExDTLS.get_cert_fingerprint(dtls)
-    {:ok, fingerprint, %{:dtls => dtls}}
+    {:ok, fingerprint, %{:dtls => dtls, :client_mode => opts[:client_mode]}}
   end
 
   @impl Handshake
-  def connection_ready(%{dtls: dtls}) do
+  def connection_ready(%{dtls: dtls, client_mode: false}), do: :ok
+
+  @impl Handshake
+  def connection_ready(%{dtls: dtls, client_mode: true}) do
     ExDTLS.do_handshake(dtls)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.DTLS.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @github_url "https://github.com/membraneframework/membrane_dtls_plugin"
 
   def project do


### PR DESCRIPTION
While in server mode we shouldn't invoke `ExDTLS.do_handshake/1` as it will do nothing. 